### PR TITLE
Topic/supported media files

### DIFF
--- a/server/handler/webhook_handler.go
+++ b/server/handler/webhook_handler.go
@@ -35,8 +35,6 @@ func LineWebHookHandler(w http.ResponseWriter, r *http.Request) {
 		replyToken := event.ReplyToken
 
 		switch linebot.MessageType(message.Type) {
-		case linebot.MessageTypeText:
-			result = message.Text
 		case linebot.MessageTypeImage:
 			b, err := line.GetMessageContent(ctx, message.Id)
 			if err != nil {
@@ -53,8 +51,7 @@ func LineWebHookHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			result = content
 		default:
-			slog.ErrorCtx(ctx, "not supported type", "type", message.Type)
-			result = "not supported"
+			result = lib.ErrNotSupportedMediaType
 		}
 
 		// reply message

--- a/server/handler/webhook_handler.go
+++ b/server/handler/webhook_handler.go
@@ -39,14 +39,24 @@ func LineWebHookHandler(w http.ResponseWriter, r *http.Request) {
 			b, err := line.GetMessageContent(ctx, message.Id)
 			if err != nil {
 				slog.ErrorCtx(ctx, "get message content error", "err", err)
-				w.WriteHeader(http.StatusInternalServerError)
+				if err := line.ReplyMessage(ctx, replyToken, lib.ErrUnknown); err != nil {
+					slog.ErrorCtx(ctx, "reply message error", "err", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
 				return
 			}
 			slog.InfoCtx(ctx, "get message content", "b", b)
 			content, err := lib.DecodeQrCode(ctx, b)
 			if err != nil {
 				slog.ErrorCtx(ctx, "decode qr code error", "err", err)
-				w.WriteHeader(http.StatusInternalServerError)
+				if err := line.ReplyMessage(ctx, replyToken, lib.ErrReadQrCode); err != nil {
+					slog.ErrorCtx(ctx, "reply message error", "err", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
 				return
 			}
 			result = content

--- a/server/lib/error.go
+++ b/server/lib/error.go
@@ -2,4 +2,6 @@ package lib
 
 const (
 	ErrNotSupportedMediaType = "申し訳ありません。このサービスは QR コードのみに対応しています。"
+	ErrReadQrCode            = "QR コードの読み取りに失敗しました。"
+	ErrUnknown               = "エラーが発生しました。再度QRコードを送信してください。"
 )

--- a/server/lib/error.go
+++ b/server/lib/error.go
@@ -1,0 +1,5 @@
+package lib
+
+const (
+	ErrNotSupportedMediaType = "申し訳ありません。このサービスは QR コードのみに対応しています。"
+)


### PR DESCRIPTION
QR コードのみの読み取りに対応させます。
テキストもしくは、QRコード以外のメディアが投稿されたらエラーメッセージを返します。