### PR TITLE
add: long term channel access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work
 # GCP
 service.yaml
 policy.yaml
+.env.yaml

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -101,11 +101,7 @@ type PostChannelAccessTokenResponse struct {
 var client *linebot.Client
 
 func NewBot(_ context.Context) error {
-	at, err := postChannelAccessToken()
-	if err != nil {
-		return err
-	}
-	bot, err := linebot.New(os.Getenv("LINE_MESSAGE_CHANNEL_SECRET"), at)
+	bot, err := linebot.New(os.Getenv("LINE_MESSAGE_CHANNEL_SECRET"), os.Getenv("LINE_CHANNEL_ACCESS_TOKEN"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
完全にミスって以下の事象が発生。

- ビルドごとに短期チャネルアクセストークンを発行する実装にしていた。
- 短期チャネルトークンの登録上限に達してしまう。
- 短期チャネルトークンの削除には実際にアクセストークンも文字列が必須 ref: https://developers.line.biz/ja/reference/messaging-api/#revoke-longlived-or-shortlived-channel-access-token
- アクセストークンを永続化していなかったので削除ができず LINE Bot がデプロイできない
  - 長期アクセストークンの利用と環境変数への埋め込み。

短期チャネルトークンの取り扱いについては [公式ドキュメント](https://developers.line.biz/ja/docs/messaging-api/channel-access-tokens/#what-are-channel-access-tokens) に記載してあった。

- 乱発禁止（API 叩くごとに発行とかしない）
- 有効期限内は再利用
- 有効期限が切れたら再度発行して一ヶ月使い回すなどの refresh の機構が必要。

短期チャネルトークンについては上記の制約があることを理解しておらず、1ヶ月有効期限の短期チャネルトークンを乱発してしまい、削除もできなくなった、というが今回の事象。
一旦有効期限が切れた頃に refesh の機構をセットで実装するための方法を実装する。また有効な短期チャネルトークンの機構についてはビルド時の他に、API アクセス時に都度有効性のチェックを行う。(DB での永続化、もしくは Cloud Scheduler の実装）