### PR TITLE
Topic/refresh token

### DIFF
--- a/server/handler/webhook_handler.go
+++ b/server/handler/webhook_handler.go
@@ -5,9 +5,8 @@ import (
 	"io"
 	"net/http"
 
-	"golang.org/x/exp/slog"
-
 	"github.com/line/line-bot-sdk-go/v7/linebot"
+	"golang.org/x/exp/slog"
 
 	"github.com/emahiro/qrurl/server/lib"
 	"github.com/emahiro/qrurl/server/lib/line"

--- a/server/intercepter/verify_channel_access_token.go
+++ b/server/intercepter/verify_channel_access_token.go
@@ -1,0 +1,34 @@
+package intercepter
+
+import (
+	"net/http"
+
+	"golang.org/x/exp/slog"
+
+	"github.com/emahiro/qrurl/server/lib/line"
+)
+
+func VerifyChannelAccessToken() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
+			ctx := origReq.Context()
+			// TODO: fetch channel access token from datastore
+			var at string
+			if at != "" {
+				valid, err := line.CheckIfTokenValid(ctx, at)
+				if err != nil {
+					slog.ErrorCtx(ctx, "failed to check if token is valid: %v", "err=", err)
+					http.Error(w, "failed to check if token is valid", http.StatusInternalServerError)
+					return
+				}
+				if !valid {
+					if err := line.NewBot(ctx, false); err != nil {
+						slog.ErrorCtx(ctx, "failed to fetch new token: %v", "err=", err)
+						panic(err)
+					}
+				}
+			}
+			next.ServeHTTP(w, origReq)
+		})
+	}
+}

--- a/server/intercepter/verify_channel_access_token.go
+++ b/server/intercepter/verify_channel_access_token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/emahiro/qrurl/server/lib/line"
 )
 
+// VerifyChannelAccessToken checks if channel access token is valid and if invalid fetch new token and new client.
 func VerifyChannelAccessToken() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
@@ -22,8 +23,13 @@ func VerifyChannelAccessToken() func(http.Handler) http.Handler {
 					return
 				}
 				if !valid {
-					if err := line.NewBot(ctx, false); err != nil {
-						slog.ErrorCtx(ctx, "failed to fetch new token: %v", "err=", err)
+					at, err := line.PostChannelAccessToken(ctx)
+					if err != nil {
+						slog.ErrorCtx(ctx, "failed to fetch new channel access token: %v", "err=", err)
+						http.Error(w, "failed to fetch new channel access token", http.StatusInternalServerError)
+					}
+					if err := line.NewBotClient(at); err != nil {
+						slog.ErrorCtx(ctx, "failed to fetch new bot client: %v", "err=", err)
 						panic(err)
 					}
 				}

--- a/server/lib/jwt/jwt.go
+++ b/server/lib/jwt/jwt.go
@@ -13,10 +13,9 @@ import (
 )
 
 func CreateToken() (string, error) {
-
 	kID := os.Getenv("LINE_PUBLIC_KEY_ID")
 	channelID := os.Getenv("LINE_CHANNEL_ID")
-	pribateKey := os.Getenv("LINE_PRIVATE_KEY")
+	privKey := os.Getenv("LINE_PRIVATE_KEY")
 
 	hdrs := jws.NewHeaders()
 	_ = hdrs.Set(jws.AlgorithmKey, "RS256")
@@ -37,8 +36,7 @@ func CreateToken() (string, error) {
 		return "", err
 	}
 
-	fmt.Printf("private key: %s\n", pribateKey)
-	key, err := jwk.ParseKey([]byte(pribateKey))
+	key, err := jwk.ParseKey([]byte(privKey))
 	if err != nil {
 		fmt.Printf("failed to parse private key: %s\n", err)
 		return "", err

--- a/server/lib/jwt/jwt.go
+++ b/server/lib/jwt/jwt.go
@@ -1,8 +1,8 @@
 package jwt
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
@@ -10,9 +10,10 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"golang.org/x/exp/slog"
 )
 
-func CreateToken() (string, error) {
+func CreateToken(ctx context.Context) (string, error) {
 	kID := os.Getenv("LINE_PUBLIC_KEY_ID")
 	channelID := os.Getenv("LINE_CHANNEL_ID")
 	privKey := os.Getenv("LINE_PRIVATE_KEY")
@@ -32,19 +33,19 @@ func CreateToken() (string, error) {
 
 	buf, err := json.MarshalIndent(t, "", "  ")
 	if err != nil {
-		fmt.Printf("failed to marshal token: %s\n", err)
+		slog.InfoCtx(ctx, "failed to marshal token error", "err", err)
 		return "", err
 	}
 
 	key, err := jwk.ParseKey([]byte(privKey))
 	if err != nil {
-		fmt.Printf("failed to parse private key: %s\n", err)
+		slog.InfoCtx(ctx, "failed to parse private key", "err", err)
 		return "", err
 	}
 
 	signed, err := jws.Sign(buf, jws.WithKey(jwa.RS256, key, jws.WithProtectedHeaders(hdrs)))
 	if err != nil {
-		fmt.Printf("failed to sign token: %s\n", err)
+		slog.InfoCtx(ctx, "failed to sign token", "err", err)
 		return "", err
 	}
 	return string(signed[:]), nil

--- a/server/lib/jwt/jwt.go
+++ b/server/lib/jwt/jwt.go
@@ -12,13 +12,12 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
-var (
-	kID        = os.Getenv("LINE_PUBLIC_KEY_ID")
-	channelID  = os.Getenv("LINE_CHANNEL_ID")
-	pribateKey = os.Getenv("LINE_PRIVATE_KEY")
-)
-
 func CreateToken() (string, error) {
+
+	kID := os.Getenv("LINE_PUBLIC_KEY_ID")
+	channelID := os.Getenv("LINE_CHANNEL_ID")
+	pribateKey := os.Getenv("LINE_PRIVATE_KEY")
+
 	hdrs := jws.NewHeaders()
 	_ = hdrs.Set(jws.AlgorithmKey, "RS256")
 	_ = hdrs.Set(jws.TypeKey, "JWT")
@@ -38,6 +37,7 @@ func CreateToken() (string, error) {
 		return "", err
 	}
 
+	fmt.Printf("private key: %s\n", pribateKey)
 	key, err := jwk.ParseKey([]byte(pribateKey))
 	if err != nil {
 		fmt.Printf("failed to parse private key: %s\n", err)

--- a/server/lib/jwt/jwt_test.go
+++ b/server/lib/jwt/jwt_test.go
@@ -1,6 +1,48 @@
 package jwt
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+const (
+	testPubKey = `{
+		"alg": "RS256",
+		"e": "AQAB",
+		"ext": true,
+		"key_ops": [
+		  "verify"
+		],
+		"kty": "RSA",
+		"n": "zunD41HNkfkfoA6EzO2HPZ2Wxk8MPC9uRDfcXClSUewY73V1dYdxw_tSuhVdS-8cLqbVCtxmLoNNnI4oz56Y36i2ouYK1hJS8W2V5XIzfj6_khaSnHrP6iqJnt-Sq2m2PJXJXqyJ-cVCXiD_YCayGaXUG7MMVMQT9GR99UFG8OYmRX-YjgYWFhHITLlF9lD8u02QvfOnh1mVL4_yHOfMQkRyiHiX6KQ3aYR49Fr-b69XVMD57v9Q1nzDlBWpABjadQ7vPvrJEEMGw9v_YnTXicfBze8DkM4iipn92EAEKkn-BaamHolBN2yhAZjSdUYibUmlc3ejZBaMUC_M-eNy6w"
+	}`
+	testPrivateKey = `{
+		"alg": "RS256",
+		"d": "BpRgakYbp1yoqMpNZsbW2hq8xKmW1gMcGoc8NqIJwBkl4dd2WLpp37WKN-ieAuAjoUgk1ieUCD6cpTHQEmoUqmgPBrcR-SS0BoFZluY-xPDx3o9hMiClo-ieX7L0UwcViG-q65vI92xSY_PgqwoP98jSKd9TsQ5bJBZd-wKMYvSf65TznL7jkVgrjV2qF1foopLWfyc7bQ1QhkYD4JkSboRbcfNgTbz0BBzk54yEnQIAbt_7P0H6JjdEvahAz1t06MVCspFgbV0aeBDuLOcHXOf40w6lISDM0_a2gMHksgPoXVc8rgZbdEEPq23eL2XvUxz97sAPdlL50SHOjMAcAQ",
+		"dp": "QGbsKGjhQzV86wUByMAwXVFZfPN12771lJyAD41BoZQ4OqE-Rj9MwjsrUu-wkahVDs7uk7atqombR0gBRyp9FRpsTloCdYPQwoqE72fHQZbAR-FQtvPlUGxftCNnGCnR5shP46NGWPQawAlUDxNyApMamdow8tEaoryAQl_yeR0",
+		"dq": "E62L7SvbU9H6FHimQmdtHpxfRTEm76B3wE0v11n8g5gHaFOZ5oBHsdVjHWdz8aAc84f59-aJVhIIgk3nA-bqAxV7nAX9DchsSbycZeHZQvYt8khwCABo7K906cYw4SCU7Zw995nswHZaABmGNDWwWUTDa_9-eOHhc2G7HskIRwE",
+		"e": "AQAB",
+		"ext": true,
+		"key_ops": [
+		  "sign"
+		],
+		"kty": "RSA",
+		"n": "zunD41HNkfkfoA6EzO2HPZ2Wxk8MPC9uRDfcXClSUewY73V1dYdxw_tSuhVdS-8cLqbVCtxmLoNNnI4oz56Y36i2ouYK1hJS8W2V5XIzfj6_khaSnHrP6iqJnt-Sq2m2PJXJXqyJ-cVCXiD_YCayGaXUG7MMVMQT9GR99UFG8OYmRX-YjgYWFhHITLlF9lD8u02QvfOnh1mVL4_yHOfMQkRyiHiX6KQ3aYR49Fr-b69XVMD57v9Q1nzDlBWpABjadQ7vPvrJEEMGw9v_YnTXicfBze8DkM4iipn92EAEKkn-BaamHolBN2yhAZjSdUYibUmlc3ejZBaMUC_M-eNy6w",
+		"p": "-XsXM7x6FbXbJYaYMS2QShx9gf8idVBuNrAF_jRAvxzO3V7UYeV5WZwIUvfKg6kQPRJkF3FrLpCRCWaxZI__gnWBNQbSUzLoVth_f9_memqd5RbrJwTgYRx64Mjg2idvOln74iW9D3D4OXEJPIzNhUSBHnzJ_qORDRdRbCKS6ms",
+		"q": "1FHqtDX4EBIecuxOWm8UO2fYR3-12reQw8UAG2NgahB6vyLoO8WXu8SHUyM1EPIIE8OKUh-T9gbaKpXuCYWvqwK6A_HiUaiXJTYfSzNMfRF8sJyL8jHFtwSI8eKb6iUtBVwdfwaskMdfxtQuGPJIngNmnhbdCLJ2vR7fZmxcuYE",
+		"qi": "-RFyvtfeTIsR8Xfa1AMmG2z080l8Vn8nVzzuqatkt6ewPNLryBlD0iWeGX-kHxMApSu2N8v-dmKKg9lDSpKvxV9jinVMvCTqRkCt73QC6rnO54LPU1LNlA-dTciPTKwtRbTvdfvfJau0T9zRHl6d0qa3F0XT5yRLqf2ngTeERDc"
+	}`
+)
+
+func TestMain(m *testing.M) {
+	os.Setenv("LINE_PUBLIC_KEY_ID", testPubKey)
+	os.Setenv("LINE_CHANNEL_ID", "lineChannelId")
+	os.Setenv("LINE_PRIVATE_KEY", testPrivateKey)
+	m.Run()
+	os.Setenv("LINE_PUBLIC_KEY_ID", "")
+	os.Setenv("LINE_CHANNEL_ID", "")
+	os.Setenv("LINE_PRIVATE_KEY", "")
+}
 
 func TestCreateToken(t *testing.T) {
 	token, err := CreateToken()

--- a/server/lib/jwt/jwt_test.go
+++ b/server/lib/jwt/jwt_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"os"
 	"testing"
 )
@@ -45,7 +46,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCreateToken(t *testing.T) {
-	token, err := CreateToken()
+	token, err := CreateToken(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -17,6 +17,10 @@ import (
 )
 
 // PostChannelAccessToken はチャンネルアクセストークンを取得する。
+// ChannelAccessToken の登録上限は30件。乱発は禁止。
+// ChannelAccessToken の上限に達すると新規の発行はできなくなるので、永続化して都度再利用、有効期限が
+// 切れたら refresh する。
+// ref: https://developers.line.biz/ja/docs/messaging-api/channel-access-tokens/
 func postChannelAccessToken(ctx context.Context) (string, error) {
 	token, err := jwt.CreateToken(ctx)
 	if err != nil {

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -33,7 +33,7 @@ func NewBot(ctx context.Context, useLongTermToken bool) error {
 			return err
 		}
 		if !valid {
-			t, err := postChannelAccessToken(ctx)
+			t, err := PostChannelAccessToken(ctx)
 			if err != nil {
 				return err
 			}
@@ -41,11 +41,20 @@ func NewBot(ctx context.Context, useLongTermToken bool) error {
 		}
 	}
 
+	if err := NewBotClient(at); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewBotClient(at string) error {
 	bot, err := linebot.New(os.Getenv("LINE_CHANNEL_SECRET"), at)
 	if err != nil {
 		return err
 	}
 
+	// set bot to singleton
 	client = bot
 	return nil
 }
@@ -79,7 +88,7 @@ func CheckIfTokenValid(ctx context.Context, token string) (bool, error) {
 // ChannelAccessToken の上限に達すると新規の発行はできなくなるので、永続化して都度再利用、有効期限が
 // 切れたら refresh する。
 // ref: https://developers.line.biz/ja/docs/messaging-api/channel-access-tokens/
-func postChannelAccessToken(ctx context.Context) (string, error) {
+func PostChannelAccessToken(ctx context.Context) (string, error) {
 	token, err := jwt.CreateToken(ctx)
 	if err != nil {
 		return "", err

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -17,8 +17,8 @@ import (
 )
 
 // PostChannelAccessToken はチャンネルアクセストークンを取得する。
-func postChannelAccessToken() (string, error) {
-	token, err := jwt.CreateToken()
+func postChannelAccessToken(ctx context.Context) (string, error) {
+	token, err := jwt.CreateToken(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -104,8 +104,17 @@ type PostChannelAccessTokenResponse struct {
 // singleton
 var client *linebot.Client
 
-func NewBot(_ context.Context) error {
-	bot, err := linebot.New(os.Getenv("LINE_MESSAGE_CHANNEL_SECRET"), os.Getenv("LINE_CHANNEL_ACCESS_TOKEN"))
+func NewBot(ctx context.Context, useLongTermToken bool) error {
+	at := os.Getenv("LINE_CHANNEL_ACCESS_TOKEN")
+	if !useLongTermToken || at != "" {
+		t, err := postChannelAccessToken(ctx)
+		if err != nil {
+			return err
+		}
+		at = t
+	}
+
+	bot, err := linebot.New(os.Getenv("LINE_MESSAGE_CHANNEL_SECRET"), at)
 	if err != nil {
 		return err
 	}

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -58,6 +58,10 @@ func postChannelAccessToken(ctx context.Context) (string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return "", err
 	}
+
+	// persist token process
+	// Datastore に取得したアクセストークン、KeyID、有効期限、ClientAssertion を保存する。
+
 	return v.AccessToken, nil
 }
 
@@ -105,8 +109,15 @@ type PostChannelAccessTokenResponse struct {
 var client *linebot.Client
 
 func NewBot(ctx context.Context, useLongTermToken bool) error {
+	// checking if latest accesstoken is valid
+	// 1. fetch token from datastore.
+	// 2. check if token is valid.
+	// 3. if valid, use it.
+	// 4. if not valid, fetch new token from LINE API or using long term token.
+
 	at := os.Getenv("LINE_CHANNEL_ACCESS_TOKEN")
 	if !useLongTermToken || at != "" {
+		// check validation
 		t, err := postChannelAccessToken(ctx)
 		if err != nil {
 			return err

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -49,7 +49,7 @@ func NewBot(ctx context.Context, useLongTermToken bool) error {
 }
 
 func NewBotClient(at string) error {
-	bot, err := linebot.New(os.Getenv("LINE_CHANNEL_SECRET"), at)
+	bot, err := linebot.New(os.Getenv("LINE_MESSAGE_CHANNEL_SECRET"), at)
 	if err != nil {
 		return err
 	}

--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -20,7 +20,7 @@ import (
 var client *linebot.Client
 
 func NewBot(ctx context.Context, useLongTermToken bool) error {
-	// checking if latest accesstoken is valid
+	// [TODO]: checking if latest accesstoken is valid
 	// 1. fetch token from datastore.
 	// 2. check if token is valid.
 	// 3. if valid, use it.

--- a/server/main.go
+++ b/server/main.go
@@ -33,7 +33,10 @@ func main() {
 	router := chi.NewRouter()
 	// 標準の http handler
 	router.Group(func(r chi.Router) {
-		r.Use(intercepter.VerifyLine())
+		r.Use(
+			intercepter.VerifyLine(),
+			intercepter.VerifyChannelAccessToken(),
+		)
 		r.HandleFunc("/v1/webhook/line", handler.LineWebHookHandler)
 	})
 

--- a/server/main.go
+++ b/server/main.go
@@ -25,7 +25,7 @@ func main() {
 	defer cancel()
 
 	// init line
-	if err := line.NewBot(ctx); err != nil {
+	if err := line.NewBot(ctx, true); err != nil {
 		slog.ErrorCtx(ctx, "failed to init line bot", "err", err)
 		panic(err)
 	}


### PR DESCRIPTION
長期チャネルアクセストークンの利用を停止したときのために、チャネルアクセストークンのリフレッシュの機構を持った middleware を追加します。

- チャネルアクセストークンの有効期限を確認する endpoint に middleware で都度アクセスする。
- アクセストークンの生成時に Datastore にアクセストークンとKeyID を登録する。
- middleware 内で毎回 Datastore にアクセストークンを呼び出しに行く（できればキャッシュしておく）