### PR TITLE
Topic/http request log

### DIFF
--- a/server/handler/webhook_handler.go
+++ b/server/handler/webhook_handler.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -15,8 +14,6 @@ import (
 
 func LineWebHookHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	fmt.Println("this is line webhook handler")
 
 	v := line.LineWebhookRequest{}
 	decorder := json.NewDecoder(r.Body)

--- a/server/handler/webhook_handler.go
+++ b/server/handler/webhook_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -14,6 +15,8 @@ import (
 
 func LineWebHookHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	fmt.Println("this is line webhook handler")
 
 	v := line.LineWebhookRequest{}
 	decorder := json.NewDecoder(r.Body)

--- a/server/intercepter/request_log_intercepter.go
+++ b/server/intercepter/request_log_intercepter.go
@@ -22,7 +22,10 @@ func NewRequestLogIntercepter() connect.UnaryInterceptorFunc {
 				tmp := strings.Split(xcTraceCtx, "/")
 				if len(tmp) == 2 {
 					traceID = tmp[0]
-					spanID = tmp[1]
+					spanIDStr := strings.Split(tmp[1], ";")
+					if len(spanIDStr) == 2 {
+						spanID = spanIDStr[0]
+					}
 				}
 				ctx = context.WithValue(ctx, log.TraceIDKey{}, traceID)
 				ctx = context.WithValue(ctx, log.SpanIDKey{}, spanID)

--- a/server/lib/log/logger.go
+++ b/server/lib/log/logger.go
@@ -94,8 +94,7 @@ func Requestf(ctx context.Context, rw *HTTPRequestLogResponseWriter, r *http.Req
 	requestSize := fmt.Sprint(r.ContentLength)
 
 	// response size を取得する
-	var wb []byte
-	if _, err := rw.Write(wb); err != nil {
+	if _, err := rw.Write([]byte{}); err != nil {
 		rw.size = 0
 	}
 	responseSize := fmt.Sprint(rw.size)

--- a/server/lib/log/logger.go
+++ b/server/lib/log/logger.go
@@ -85,28 +85,25 @@ func Requestf(ctx context.Context, rw http.ResponseWriter, r *http.Request) {
 	}
 	duration := makeDuration(time.Since(requestTime))
 
-	defer func() {
-		logger.InfoCtx(ctx, "Default http request info",
-			slog.String("logName", "projects/"+projectID+"/logs/qrurl-app%2FhttpRequestLog"),
-			slog.String("severity", slog.LevelInfo.String()),
-			slog.Any("httpRequest", httpRequest{
-				RequestMethod: r.Method,
-				RequestUrl:    r.URL.String(),
-				RequestSize:   requestSize,
-				ResponseSize:  responseSize,
-				UserAgent:     r.UserAgent(),
-				Protocol:      r.Proto,
-				RemoteIp:      r.RemoteAddr,
-				Referer:       r.Referer(),
-				Latency:       duration,
-			}),
-			slog.Any("rawHttpHeader", r.Header),
-			slog.Time("time", requestTime),
-			slog.String("logging.googleapis.com/spanId", spanID),
-			slog.String("logging.googleapis.com/trace", "projects/"+projectID+"/traces/"+traceID),
-		)
-	}()
-
+	logger.InfoCtx(ctx, "Default http request info",
+		slog.String("logName", "projects/"+projectID+"/logs/qrurl-app%2FhttpRequestLog"),
+		slog.String("severity", slog.LevelInfo.String()),
+		slog.Any("httpRequest", httpRequest{
+			RequestMethod: r.Method,
+			RequestUrl:    r.URL.String(),
+			RequestSize:   requestSize,
+			ResponseSize:  responseSize,
+			UserAgent:     r.UserAgent(),
+			Protocol:      r.Proto,
+			RemoteIp:      r.RemoteAddr,
+			Referer:       r.Referer(),
+			Latency:       duration,
+		}),
+		slog.Any("rawHttpHeader", r.Header),
+		slog.Time("time", requestTime),
+		slog.String("logging.googleapis.com/spanId", spanID),
+		slog.String("logging.googleapis.com/trace", "projects/"+projectID+"/traces/"+traceID),
+	)
 }
 
 type ConnectRequestInfo struct {

--- a/server/lib/log/logger.go
+++ b/server/lib/log/logger.go
@@ -118,7 +118,6 @@ type ConnectRequestInfo struct {
 }
 
 func ConnectRequestf(ctx context.Context, info ConnectRequestInfo) {
-	now := time.Now()
 	req := info.Req
 	resp := info.Resp
 

--- a/server/lib/log/logger.go
+++ b/server/lib/log/logger.go
@@ -111,7 +111,7 @@ func Requestf(ctx context.Context, rw *HTTPRequestLogResponseWriter, r *http.Req
 		slog.Any("httpRequest", httpRequest{
 			RequestMethod: r.Method,
 			Status:        rw.statusCode,
-			RequestUrl:    r.URL.String(),
+			RequestUrl:    "https://" + r.Host + r.URL.String(),
 			RequestSize:   requestSize,
 			ResponseSize:  responseSize,
 			UserAgent:     r.UserAgent(),

--- a/server/main.go
+++ b/server/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	middleware.Chain(mux,
+		middleware.RequestLog,
 		middleware.VerifyChannelAccessToken,
 		middleware.VerifyLine,
 	)

--- a/server/main.go
+++ b/server/main.go
@@ -56,6 +56,9 @@ func main() {
 		middleware.VerifyLine,
 	)
 	mux.HandleFunc("/v1/webhook/line", handler.LineWebHookHandler)
+	mux.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "{\"message\": \"pong\"}}")
+	}))
 
 	intercepters := connect.WithInterceptors(
 		intercepter.NewRequestLogIntercepter(),

--- a/server/main.go
+++ b/server/main.go
@@ -50,15 +50,10 @@ func main() {
 	})
 
 	mux := http.NewServeMux()
-	mwchain := middleware.Chain(mux,
-		middleware.RequestLog,
-	)
-	mux.Handle("/v1/webhook/line", middleware.Chain(mux, middleware.VerifyLine, middleware.VerifyChannelAccessToken, func(h http.Handler) http.Handler {
-		return http.HandlerFunc(handler.LineWebHookHandler)
-	}))
-	mux.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "{\"message\": \"pong\"}}")
-	}))
+	mwchain := middleware.Chain(mux, middleware.RequestLog)
+
+	mux.Handle("/v1/webhook/line", middleware.Chain(http.HandlerFunc(handler.LineWebHookHandler), middleware.VerifyChannelAccessToken, middleware.VerifyLine))
+	mux.Handle("/ping", middleware.Chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprintf(w, "{\"message\": \"pong\"}}") })))
 
 	intercepters := connect.WithInterceptors(
 		intercepter.NewRequestLogIntercepter(),

--- a/server/main.go
+++ b/server/main.go
@@ -50,10 +50,8 @@ func main() {
 	})
 
 	mux := http.NewServeMux()
-	mwchain := middleware.Chain(mux, middleware.RequestLog)
-
-	mux.Handle("/v1/webhook/line", middleware.Chain(http.HandlerFunc(handler.LineWebHookHandler), middleware.VerifyChannelAccessToken, middleware.VerifyLine))
-	mux.Handle("/ping", middleware.Chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprintf(w, "{\"message\": \"pong\"}}") })))
+	mux.Handle("/v1/webhook/line", middleware.Chain(http.HandlerFunc(handler.LineWebHookHandler), middleware.VerifyChannelAccessToken, middleware.VerifyLine, middleware.RequestLog))
+	mux.Handle("/ping", middleware.Chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { fmt.Fprintf(w, "{\"message\": \"pong\"}}") }), middleware.RequestLog))
 
 	intercepters := connect.WithInterceptors(
 		intercepter.NewRequestLogIntercepter(),
@@ -63,7 +61,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:    addr,
-		Handler: c.Handler(h2c.NewHandler(mwchain, &http2.Server{})),
+		Handler: c.Handler(h2c.NewHandler(mux, &http2.Server{})),
 	}
 	go func() {
 		<-ctx.Done()

--- a/server/middleware/request_log.go
+++ b/server/middleware/request_log.go
@@ -1,9 +1,20 @@
 package middleware
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/emahiro/qrurl/server/lib/log"
+)
 
 func RequestLog(http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
-
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		requestTime := time.Now()
+		ctx = context.WithValue(ctx, log.RequestTimeKey{}, requestTime)
+		defer func() {
+			log.Requestf(ctx, w, r)
+		}()
 	})
 }

--- a/server/middleware/request_log.go
+++ b/server/middleware/request_log.go
@@ -8,13 +8,17 @@ import (
 	"github.com/emahiro/qrurl/server/lib/log"
 )
 
-func RequestLog(http.Handler) http.Handler {
+func RequestLog(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		requestTime := time.Now()
 		ctx = context.WithValue(ctx, log.RequestTimeKey{}, requestTime)
+
+		lrw := log.NewLogHTTPResponseWriter(w)
+		next.ServeHTTP(lrw, r)
+
 		defer func() {
-			log.Requestf(ctx, w, r)
+			log.Requestf(ctx, lrw, r)
 		}()
 	})
 }

--- a/server/middleware/request_log.go
+++ b/server/middleware/request_log.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/emahiro/qrurl/server/lib/log"
@@ -13,6 +14,18 @@ func RequestLog(next http.Handler) http.Handler {
 		ctx := r.Context()
 		requestTime := time.Now()
 		ctx = context.WithValue(ctx, log.RequestTimeKey{}, requestTime)
+
+		xcTraceCtx := r.Header.Get("X-Cloud-Trace-Context")
+		var traceID, spanID string
+		if xcTraceCtx != "" {
+			tmp := strings.Split(xcTraceCtx, "/")
+			if len(tmp) == 2 {
+				traceID = tmp[0]
+				spanID = tmp[1]
+			}
+			ctx = context.WithValue(ctx, log.TraceIDKey{}, traceID)
+			ctx = context.WithValue(ctx, log.SpanIDKey{}, spanID)
+		}
 
 		lrw := log.NewLogHTTPResponseWriter(w)
 		next.ServeHTTP(lrw, r)

--- a/server/middleware/request_log.go
+++ b/server/middleware/request_log.go
@@ -1,0 +1,9 @@
+package middleware
+
+import "net/http"
+
+func RequestLog(http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
+
+	})
+}

--- a/server/middleware/request_log.go
+++ b/server/middleware/request_log.go
@@ -21,7 +21,10 @@ func RequestLog(next http.Handler) http.Handler {
 			tmp := strings.Split(xcTraceCtx, "/")
 			if len(tmp) == 2 {
 				traceID = tmp[0]
-				spanID = tmp[1]
+				spanIDStr := strings.Split(tmp[1], ";")
+				if len(spanIDStr) == 2 {
+					spanID = spanIDStr[0]
+				}
 			}
 			ctx = context.WithValue(ctx, log.TraceIDKey{}, traceID)
 			ctx = context.WithValue(ctx, log.SpanIDKey{}, spanID)

--- a/server/middleware/verify_channel_access_token.go
+++ b/server/middleware/verify_channel_access_token.go
@@ -10,7 +10,7 @@ import (
 )
 
 // VerifyChannelAccessToken checks if channel access token is valid and if invalid fetch new token and new client.
-func VerifyChannelAccessToken(http.Handler) http.Handler {
+func VerifyChannelAccessToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
 		ctx := origReq.Context()
 		repo := repository.LineChannelAccessTokenRepository{}
@@ -39,5 +39,6 @@ func VerifyChannelAccessToken(http.Handler) http.Handler {
 				}
 			}
 		}
+		next.ServeHTTP(w, origReq)
 	})
 }

--- a/server/middleware/verify_line_intercepter.go
+++ b/server/middleware/verify_line_intercepter.go
@@ -12,10 +12,9 @@ import (
 
 var lineMessageChannelSecret = os.Getenv("LINE_MESSAGE_CHANNEL_SECRET")
 
-func VerifyLine(http.Handler) http.Handler {
+func VerifyLine(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, origReq *http.Request) {
 		ctx := origReq.Context()
-
 		copyReq := origReq.Clone(ctx)
 		b, err := io.ReadAll(copyReq.Body)
 		if err != nil {
@@ -37,7 +36,7 @@ func VerifyLine(http.Handler) http.Handler {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-
 		origReq.Body = io.NopCloser(bytes.NewBuffer(b))
+		next.ServeHTTP(w, origReq)
 	})
 }


### PR DESCRIPTION
CloudLogging の構造化ログを slog で実装する #40 の修正です。

- gRPC の Endpoint のみでなく、Rest の Endpoint にも対応させました。
- middleware の差し込み実装の仕方が間違っていたので、middleware の処理を登録できるようにしました。
- 別途 Firestore の書き込みができるように権限を変更しました。
- response の情報が必要なので context に request/response の情報を context に情報を含めるようにしました。

実装的には Chain に Mux 全てにかけたいところですが、同じ Mux を使っている gRPC の Endpoint にも HTTP の Request の Log が出力されてしまうので、gRPC の Intercepter に登録するときと同様の実装を入れました。