### PR TITLE
fix: follow Go1.23 in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,17 +13,17 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ./server
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
Go1.23 に Workflow を対応させる