### PR TITLE
Update Go version to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,8 +1,8 @@
 module github.com/emahiro/qrurl/server
 
-go 1.23
+go 1.24
 
-toolchain go1.23.0
+toolchain go1.24.0
 
 require (
 	cloud.google.com/go/firestore v1.11.0


### PR DESCRIPTION
This commit updates the project to use Go 1.24.

Changes include:
- Updated `server/go.mod` to `go 1.24` and `toolchain go1.24.0`.
- Updated CI workflow in `.github/workflows/go.yml` to use `go-version: [1.24.x]`.
- Verified that the project builds, vets, and tests successfully with Go 1.24.
- Ran `go mod tidy` to ensure `go.mod` and `go.sum` are consistent.