### PR TITLE
fix(server): fix return leak in token verification middleware and sanitize logging

### DIFF
--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -95,7 +95,6 @@ func PostChannelAccessToken(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", log.WithStackTracef(err, "failed to create jwt token")
 	}
-	log.Infof(context.Background(), "token: %s", token)
 
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")

--- a/server/middleware/verify_channel_access_token.go
+++ b/server/middleware/verify_channel_access_token.go
@@ -15,25 +15,26 @@ func VerifyChannelAccessToken(next http.Handler) http.Handler {
 		repo := repository.LineChannelAccessTokenRepository{}
 		at, err := repo.GetLatestAccessToken(ctx)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to fetch latest access token: %v", "err=", err)
+			slog.ErrorContext(ctx, "failed to fetch latest access token", "err", err)
 			http.Error(w, "failed to fetch latest access token", http.StatusInternalServerError)
 			return
 		}
 		if at != "" {
 			valid, err := line.CheckIfTokenValid(ctx, at)
 			if err != nil {
-				slog.ErrorContext(ctx, "failed to check if token is valid: %v", "err=", err)
+				slog.ErrorContext(ctx, "failed to check if token is valid", "err", err)
 				http.Error(w, "failed to check if token is valid", http.StatusInternalServerError)
 				return
 			}
 			if !valid {
 				at, err := line.PostChannelAccessToken(ctx)
 				if err != nil {
-					slog.ErrorContext(ctx, "failed to fetch new channel access token: %v", "err=", err)
+					slog.ErrorContext(ctx, "failed to fetch new channel access token", "err", err)
 					http.Error(w, "failed to fetch new channel access token", http.StatusInternalServerError)
+					return
 				}
 				if err := line.NewBotClient(at); err != nil {
-					slog.ErrorContext(ctx, "failed to fetch new bot client: %v", "err=", err)
+					slog.ErrorContext(ctx, "failed to fetch new bot client", "err", err)
 					panic(err)
 				}
 			}


### PR DESCRIPTION
Fixes a serious bug where requests leak and continue despite a failed token refresh inside the `VerifyChannelAccessToken` middleware. Also fixes formatting issues with `slog.ErrorContext` and removes plain JWT log leak in `PostChannelAccessToken` for improved security.