### PR TITLE
refactor(server): set timeout on HTTP client and decouple Connect RPC from lib layer

### DIFF
--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -20,6 +20,10 @@ import (
 // singleton
 var client *linebot.Client
 
+var httpClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
 func NewBot(ctx context.Context, useLongTermToken bool) error {
 	var at string
 	if !useLongTermToken {
@@ -72,7 +76,7 @@ func CheckIfTokenValid(ctx context.Context, token string) (bool, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -108,7 +112,7 @@ func PostChannelAccessToken(ctx context.Context) (string, error) {
 		return "", log.WithStackTracef(err, "failed to create request")
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", log.WithStackTracef(err, "failed to request")
 	}

--- a/server/lib/qr_code.go
+++ b/server/lib/qr_code.go
@@ -3,10 +3,10 @@ package lib
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image"
 	"log/slog"
 
-	"github.com/bufbuild/connect-go"
 	"github.com/makiuchi-d/gozxing"
 	"github.com/makiuchi-d/gozxing/qrcode"
 )
@@ -16,20 +16,20 @@ func DecodeQrCode(ctx context.Context, b []byte) (string, error) {
 	img, _, err := image.Decode(buf)
 	if err != nil {
 		slog.ErrorContext(ctx, "image.Decode", "err", err)
-		return "", connect.NewError(connect.CodeInvalidArgument, err)
+		return "", fmt.Errorf("failed to decode image: %w", err)
 	}
 
 	bmp, err := gozxing.NewBinaryBitmapFromImage(img)
 	if err != nil {
 		slog.ErrorContext(ctx, "NewBinaryBitmapFromImage", "err", err)
-		return "", connect.NewError(connect.CodeUnknown, err)
+		return "", fmt.Errorf("failed to create binary bitmap: %w", err)
 	}
 
 	reader := qrcode.NewQRCodeReader()
 	result, err := reader.Decode(bmp, nil)
 	if err != nil {
 		slog.ErrorContext(ctx, "reader.Decode", "err", err)
-		return "", connect.NewError(connect.CodeUnknown, err)
+		return "", fmt.Errorf("failed to decode qr code: %w", err)
 	}
 	return result.GetText(), nil
 }

--- a/server/service/qrurl_service.go
+++ b/server/service/qrurl_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	_ "image/jpeg"
 	_ "image/png"
+	"strings"
 
 	"github.com/bufbuild/connect-go"
 
@@ -21,11 +22,14 @@ func (s *QrUrlService) PostQrCode(
 ) (resp *connect.Response[qrurlv1.PostQrCodeResponse], err error) {
 	b, err := base64.StdEncoding.DecodeString(req.Msg.Image)
 	if err != nil {
-		return nil, log.WithStackTracef(err, "decode error. image: %v", req.Msg.Image)
+		return nil, connect.NewError(connect.CodeInvalidArgument, log.WithStackTracef(err, "failed to decode base64 image"))
 	}
 	url, err := lib.DecodeQrCode(ctx, b)
 	if err != nil {
-		return nil, log.WithStackTracef(err, "decode error. image: %v", req.Msg.Image)
+		if strings.Contains(err.Error(), "failed to decode image") {
+			return nil, connect.NewError(connect.CodeInvalidArgument, log.WithStackTracef(err, "invalid image format"))
+		}
+		return nil, connect.NewError(connect.CodeUnknown, log.WithStackTracef(err, "failed to decode QR code"))
 	}
 	qrurlResp := &qrurlv1.PostQrCodeResponse{
 		Url: url,


### PR DESCRIPTION
Prevents resource leaks by assigning a 10-second timeout on the HTTP client for outgoing LINE API requests. Also decouples `connect-go` from the `lib/qr_code.go` layer, returning standard Go errors instead, with proper error mapping handled at the service layer boundaries.