### PR TITLE
refactor(server): separate data model entity and database repository layers

### DIFF
--- a/server/lib/line/line.go
+++ b/server/lib/line/line.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/emahiro/qrurl/server/lib/jwt"
 	"github.com/emahiro/qrurl/server/lib/log"
+	"github.com/emahiro/qrurl/server/model"
 	"github.com/emahiro/qrurl/server/repository"
 )
 
@@ -132,7 +133,7 @@ func PostChannelAccessToken(ctx context.Context) (string, error) {
 	// Datastore に取得したアクセストークン、KeyID、有効期限、ClientAssertion を保存する。
 	now := time.Now().Unix()
 	lineChannelAccessTokenRepo := repository.LineChannelAccessTokenRepository{}
-	if err := lineChannelAccessTokenRepo.Create(ctx, repository.LineChannelAccessTokenRepository{
+	if err := lineChannelAccessTokenRepo.Create(ctx, model.LineChannelAccessToken{
 		AccessToken:     v.AccessToken,
 		ExpiresIn:       v.ExpiresIn,
 		KeyID:           v.KeyID,

--- a/server/model/line_channel_access_token.go
+++ b/server/model/line_channel_access_token.go
@@ -1,0 +1,11 @@
+package model
+
+type LineChannelAccessToken struct {
+	AccessToken     string `firestore:"access_token,omitempty"`
+	TokenType       string `firestore:"token_type,omitempty"`
+	ExpiresIn       int64  `firestore:"expires_in,omitempty"`
+	KeyID           string `firestore:"key_id,omitempty"`
+	ClientAssertion string `firestore:"client_assertion,omitempty"`
+	CreatedAt       int64  `firestore:"created_at,omitempty"`
+	UpdatedAt       int64  `firestore:"updated_at,omitempty"`
+}

--- a/server/repository/line_channel_accesstoken_repository.go
+++ b/server/repository/line_channel_accesstoken_repository.go
@@ -4,26 +4,19 @@ import (
 	"context"
 
 	"github.com/emahiro/qrurl/server/infra/firestore"
+	"github.com/emahiro/qrurl/server/model"
 )
 
-type LineChannelAccessTokenRepository struct {
-	AccessToken     string `firestore:"access_token,omitempty"`
-	TokenType       string `firestore:"token_type,omitempty"`
-	ExpiresIn       int64  `firestore:"expires_in,omitempty"`
-	KeyID           string `firestore:"key_id,omitempty"`
-	ClientAssertion string `firestore:"client_assertion,omitempty"`
-	CreatedAt       int64  `firestore:"created_at,omitempty"`
-	UpdatedAt       int64  `firestore:"updated_at,omitempty"`
-}
+type LineChannelAccessTokenRepository struct{}
 
 const LineChannelAccessTokenCollection = "LineChannelAccessToken"
 
-func (r LineChannelAccessTokenRepository) Create(ctx context.Context, src LineChannelAccessTokenRepository) error {
+func (r LineChannelAccessTokenRepository) Create(ctx context.Context, src model.LineChannelAccessToken) error {
 	return firestore.Add(ctx, LineChannelAccessTokenCollection, src)
 }
 
 func (r LineChannelAccessTokenRepository) GetLatestAccessToken(ctx context.Context) (string, error) {
-	dst, err := firestore.Query[LineChannelAccessTokenRepository](ctx, LineChannelAccessTokenCollection, firestore.QueryOption{
+	dst, err := firestore.Query[model.LineChannelAccessToken](ctx, LineChannelAccessTokenCollection, firestore.QueryOption{
 		OrderBy: "created_at",
 		Desc:    true,
 		Limit:   1,


### PR DESCRIPTION
Splits data model definitions from repository layers by separating the DB schema struct into `model.LineChannelAccessToken` and refactoring `LineChannelAccessTokenRepository` to act purely as a data access layer. Improves readability and mockability.