### PR TITLE
fix(deploy): bump Go version in Dockerfile and CI workflow to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-bookworm
+FROM golang:1.26-bookworm
 
 RUN mkdir /app
 


### PR DESCRIPTION
Bumps the Go version in `server/Dockerfile` to `1.26-bookworm` to resolve the version mismatch with `go.mod` (which requires `>= 1.26`). Also bumps the Go version in `.github/workflows/go.yml` to `1.26.x` for consistency. This resolves the deployment failure in the `Deploy` workflow.