### PR TITLE
fix(client/deploy): bump Node version in Dockerfile to 22 for Vite 8 compatibility

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM node:20.4-alpine as react-build
+FROM node:22-alpine as react-build
 WORKDIR /app
 COPY . ./
 COPY .env ./.env


### PR DESCRIPTION
Bumps the Node.js base image version in `client/Dockerfile` to `node:22-alpine` (Node 22) to resolve the execution failure of Vite 8 and Rolldown (which require `node >= 20.19` or `node >= 22.12`). This resolves the deployment failure in the `Deploy Client` workflow.